### PR TITLE
Add CRM entry expansion animation

### DIFF
--- a/src/components/adminPanel/adminPanel.css
+++ b/src/components/adminPanel/adminPanel.css
@@ -740,6 +740,15 @@
   color: #374151;
   line-height: 1.5;
   margin-top: 8px;
+  transform-origin: top center;
+}
+
+.crm-entry-content.opening {
+  animation: crmExpand 0.6s cubic-bezier(0.22, 1.2, 0.36, 1) forwards;
+}
+
+.crm-entry-content.closing {
+  animation: crmCollapse 0.4s cubic-bezier(0.4, 0, 0.2, 1) forwards;
 }
 
 .delete-crm-button {
@@ -877,6 +886,37 @@
   to {
     opacity: 0;
     transform: scale(0.95);
+  }
+}
+
+@keyframes crmExpand {
+  0% {
+    transform: scaleY(0.85) rotateX(8deg);
+    opacity: 0;
+  }
+  50% {
+    transform: scaleY(1.1) rotateX(-5deg);
+  }
+  75% {
+    transform: scaleY(0.95) rotateX(3deg);
+  }
+  100% {
+    transform: scaleY(1) rotateX(0);
+    opacity: 1;
+  }
+}
+
+@keyframes crmCollapse {
+  0% {
+    transform: scaleY(1) rotateX(0);
+    opacity: 1;
+  }
+  40% {
+    transform: scaleY(1.2) rotateX(-12deg);
+  }
+  100% {
+    transform: scaleY(0) rotateX(0);
+    opacity: 0;
   }
 }
 

--- a/src/components/adminPanel/adminPanel.jsx
+++ b/src/components/adminPanel/adminPanel.jsx
@@ -69,6 +69,14 @@ export default function AdminPanel({ data: initialData, currentUser }) {
   const [showNewPassword, setShowNewPassword] = useState(false)
   const [successMessage, setSuccessMessage] = useState("")
   const [expandedCrmEntries, setExpandedCrmEntries] = useState({})
+  const [closingCrmEntry, setClosingCrmEntry] = useState(null)
+
+  useEffect(() => {
+    if (closingCrmEntry) {
+      const timer = setTimeout(() => setClosingCrmEntry(null), 400)
+      return () => clearTimeout(timer)
+    }
+  }, [closingCrmEntry])
 
   // Modal closing states
   const [modalClosing, setModalClosing] = useState({
@@ -339,10 +347,20 @@ export default function AdminPanel({ data: initialData, currentUser }) {
   }
 
   const toggleCrmExpansion = (entryId) => {
-    setExpandedCrmEntries((prev) => ({
-      ...prev,
-      [entryId]: !prev[entryId],
-    }))
+    setExpandedCrmEntries((prev) => {
+      const isOpen = prev[entryId]
+      const openId = Object.keys(prev)[0]
+      const newState = {}
+      if (isOpen) {
+        setClosingCrmEntry(entryId)
+        return newState
+      }
+      if (openId && openId !== entryId) {
+        setClosingCrmEntry(openId)
+      }
+      newState[entryId] = true
+      return newState
+    })
   }
 
   const handleLogout = async () => {
@@ -1238,7 +1256,13 @@ export default function AdminPanel({ data: initialData, currentUser }) {
                     </button>
                   )}
                 </div>
-                {expandedCrmEntries[entry.id] && <p className="crm-entry-content">{entry.content}</p>}
+                {(expandedCrmEntries[entry.id] || closingCrmEntry === entry.id) && (
+                  <p
+                    className={`crm-entry-content ${closingCrmEntry === entry.id ? "closing" : "opening"}`}
+                  >
+                    {entry.content}
+                  </p>
+                )}
               </div>
             ))
           ) : (

--- a/src/components/employeePanel/employeePanel.css
+++ b/src/components/employeePanel/employeePanel.css
@@ -873,6 +873,15 @@ body {
   background-color: #f8fafc;
   border-radius: 8px;
   border-left: 3px solid #8b5cf6;
+  transform-origin: top center;
+}
+
+.crm-entry-content.opening {
+  animation: crmExpand 0.6s cubic-bezier(0.22, 1.2, 0.36, 1) forwards;
+}
+
+.crm-entry-content.closing {
+  animation: crmCollapse 0.4s cubic-bezier(0.4, 0, 0.2, 1) forwards;
 }
 
 .edit-button {
@@ -1348,6 +1357,37 @@ body {
   to {
     opacity: 1;
     transform: translateY(0);
+  }
+}
+
+@keyframes crmExpand {
+  0% {
+    transform: scaleY(0.85) rotateX(8deg);
+    opacity: 0;
+  }
+  50% {
+    transform: scaleY(1.1) rotateX(-5deg);
+  }
+  75% {
+    transform: scaleY(0.95) rotateX(3deg);
+  }
+  100% {
+    transform: scaleY(1) rotateX(0);
+    opacity: 1;
+  }
+}
+
+@keyframes crmCollapse {
+  0% {
+    transform: scaleY(1) rotateX(0);
+    opacity: 1;
+  }
+  40% {
+    transform: scaleY(1.2) rotateX(-12deg);
+  }
+  100% {
+    transform: scaleY(0) rotateX(0);
+    opacity: 0;
   }
 }
 

--- a/src/components/employeePanel/employeePanel.jsx
+++ b/src/components/employeePanel/employeePanel.jsx
@@ -48,6 +48,14 @@ export default function EmployeePanel({ data: initialData, currentUser, username
   const [isLogoutOpen, setIsLogoutOpen] = useState(false)
   const [sameAsRegistration, setSameAsRegistration] = useState(true)
   const [expandedCrmEntries, setExpandedCrmEntries] = useState({})
+  const [closingCrmEntry, setClosingCrmEntry] = useState(null)
+
+  useEffect(() => {
+    if (closingCrmEntry) {
+      const timer = setTimeout(() => setClosingCrmEntry(null), 400)
+      return () => clearTimeout(timer)
+    }
+  }, [closingCrmEntry])
   const [employeeUsername, setEmployeeUsername] = useState(username);
   const [crmTickets, setCrmTickets] = useState([]);
 
@@ -218,9 +226,17 @@ export default function EmployeePanel({ data: initialData, currentUser, username
 
   const toggleCrmExpansion = (entryId) => {
     setExpandedCrmEntries((prev) => {
-      // Close all other entries and toggle the clicked one
+      const isOpen = prev[entryId]
+      const openId = Object.keys(prev)[0]
       const newState = {}
-      newState[entryId] = !prev[entryId]
+      if (isOpen) {
+        setClosingCrmEntry(entryId)
+        return newState
+      }
+      if (openId && openId !== entryId) {
+        setClosingCrmEntry(openId)
+      }
+      newState[entryId] = true
       return newState
     })
   }
@@ -1725,7 +1741,14 @@ const handleUpdateCrm = async (e) => {
                         </div>
                     </div>
                 </div>
-                {expandedCrmEntries[entry.id || `crm-${i}`] && <div style={{ whiteSpace: 'pre-wrap', overflowWrap: 'break-word'}} className="crm-entry-content">{entry.content}</div>}
+                {(expandedCrmEntries[entry.id || `crm-${i}`] || closingCrmEntry === (entry.id || `crm-${i}`)) && (
+                  <div
+                    style={{ whiteSpace: 'pre-wrap', overflowWrap: 'break-word'}}
+                    className={`crm-entry-content ${closingCrmEntry === (entry.id || `crm-${i}`) ? 'closing' : 'opening'}`}
+                  >
+                    {entry.content}
+                  </div>
+                )}
             </div>
         ))
     ) : (


### PR DESCRIPTION
## Summary
- animate CRM entry open/close similar to success message popup
- keep only one CRM entry expanded at a time
- add crmExpand/crmCollapse keyframes and classes

## Testing
- `npm run lint` *(fails: showPopup is not defined and other errors)*
- `npm run build` *(fails: Cannot find module @rollup/rollup-linux-x64-gnu)*

------
https://chatgpt.com/codex/tasks/task_e_68496e9e2cb4832ba89082883ac16972