### PR TITLE
Fix CRM history details

### DIFF
--- a/src/components/adminPanel/adminPanel.css
+++ b/src/components/adminPanel/adminPanel.css
@@ -757,12 +757,14 @@
   transform-origin: top center;
 }
 
+
 .crm-entry-content.opening {
-  animation: crmExpand 0.6s cubic-bezier(0.22, 1.2, 0.36, 1) forwards;
+  animation: crmExpand 0.3s ease forwards;
 }
 
+
 .crm-entry-content.closing {
-  animation: crmCollapse 0.4s cubic-bezier(0.4, 0, 0.2, 1) forwards;
+  animation: crmCollapse 0.2s ease forwards;
 }
 
 .delete-crm-button {
@@ -904,32 +906,23 @@
 }
 
 @keyframes crmExpand {
-  0% {
-    transform: scaleY(0.85) rotateX(8deg);
+  from {
+    transform: scaleY(0);
     opacity: 0;
   }
-  50% {
-    transform: scaleY(1.1) rotateX(-5deg);
-  }
-  75% {
-    transform: scaleY(0.95) rotateX(3deg);
-  }
-  100% {
-    transform: scaleY(1) rotateX(0);
+  to {
+    transform: scaleY(1);
     opacity: 1;
   }
 }
 
 @keyframes crmCollapse {
-  0% {
-    transform: scaleY(1) rotateX(0);
+  from {
+    transform: scaleY(1);
     opacity: 1;
   }
-  40% {
-    transform: scaleY(1.2) rotateX(-12deg);
-  }
-  100% {
-    transform: scaleY(0) rotateX(0);
+  to {
+    transform: scaleY(0);
     opacity: 0;
   }
 }

--- a/src/components/adminPanel/adminPanel.jsx
+++ b/src/components/adminPanel/adminPanel.jsx
@@ -531,7 +531,7 @@ export default function AdminPanel({ data: initialData, currentUser }) {
   }
 
   const canDeleteCrmEntry = (entry) => {
-    return entry.employeeName === currentUser?.username
+    return (entry.employeeName || entry.username) === currentUser?.username
   }
 
   const renderPersonList = () => {
@@ -1024,7 +1024,7 @@ export default function AdminPanel({ data: initialData, currentUser }) {
                     {expandedCrmEntries[entry.id] ? <ChevronDown size={16} /> : <ChevronRight size={16} />}
                     <span className="crm-entry-badge">{entry.contactType}</span>
                     <span className="crm-entry-meta">{entry.date}</span>
-                    <span className="crm-entry-meta">by {entry.employeeName}</span>
+                    <span className="crm-entry-meta">by {entry.employeeName || entry.username}</span>
                   </div>
                   {canDeleteCrmEntry(entry) && (
                     <button

--- a/src/components/employeePanel/employeePanel.jsx
+++ b/src/components/employeePanel/employeePanel.jsx
@@ -908,8 +908,8 @@ export default function EmployeePanel({ data: initialData, currentUser, username
 
     // Generate a 1-based numeric ID for the new CRM entry
     // This ID will be used for both local state and sent to the backend.
-    const newId = (selectedPerson.crm && selectedPerson.crm.length > 0)
-      ? Math.max(...selectedPerson.crm.map(entry => entry.id || 0)) + 1 // Find max existing ID and add 1
+    const newId = (selectedPerson.crmEntries && selectedPerson.crmEntries.length > 0)
+      ? Math.max(...selectedPerson.crmEntries.map(entry => entry.id || 0)) + 1 // Find max existing ID and add 1
       : 1; // Start with 1 if no existing CRM entries
 
     const crmData = {
@@ -953,7 +953,7 @@ export default function EmployeePanel({ data: initialData, currentUser, username
 
       const updatedPerson = {
         ...selectedPerson,
-        crm: [...(selectedPerson.crm || []), newCrmEntry],
+        crmEntries: [...(selectedPerson.crmEntries || []), newCrmEntry],
       };
 
       setData((prev) => prev.map((person) => (person.id === selectedPerson.id ? updatedPerson : person)));
@@ -996,7 +996,7 @@ export default function EmployeePanel({ data: initialData, currentUser, username
     if (!validateCrmForm()) return;
     if (!editingCrmEntry || !selectedPerson) return;
 
-    const entryIndex = selectedPerson.crm.findIndex(
+    const entryIndex = selectedPerson.crmEntries.findIndex(
       (entry) =>
         entry.id === editingCrmEntry.id &&
         entry.username === editingCrmEntry.username &&
@@ -1033,7 +1033,7 @@ export default function EmployeePanel({ data: initialData, currentUser, username
       }
 
       // Update the local state's `crm` array
-      const updatedCrmEntries = selectedPerson.crm.map((entry) =>
+      const updatedCrmEntries = selectedPerson.crmEntries.map((entry) =>
         entry.id === editingCrmEntry.id &&
           entry.title === editingCrmEntry.title &&
           entry.contact_type === editingCrmEntry.contact_type &&
@@ -1054,7 +1054,7 @@ export default function EmployeePanel({ data: initialData, currentUser, username
 
       const updatedPerson = {
         ...selectedPerson,
-        crm: updatedCrmEntries,
+        crmEntries: updatedCrmEntries,
       };
 
       setData((prev) => prev.map((person) => (person.id === selectedPerson.id ? updatedPerson : person)));
@@ -1089,7 +1089,7 @@ export default function EmployeePanel({ data: initialData, currentUser, username
     if (!deletingCrmEntry || !selectedPerson) return;
 
 
-    const entryIndex = selectedPerson.crm.findIndex(
+    const entryIndex = selectedPerson.crmEntries.findIndex(
       (entry) =>
         entry &&
         entry.username === deletingCrmEntry.username &&
@@ -1139,7 +1139,7 @@ export default function EmployeePanel({ data: initialData, currentUser, username
 
       }
 
-      const updatedCrmEntries = selectedPerson.crm.filter(
+      const updatedCrmEntries = selectedPerson.crmEntries.filter(
         (entry) =>
           !(
             entry.username === deletingCrmEntry.username &&
@@ -1152,7 +1152,7 @@ export default function EmployeePanel({ data: initialData, currentUser, username
 
       const updatedPerson = {
         ...selectedPerson,
-        crm: updatedCrmEntries,
+        crmEntries: updatedCrmEntries,
       };
 
       setData((prev) =>
@@ -1174,11 +1174,11 @@ export default function EmployeePanel({ data: initialData, currentUser, username
 
 
   const canDeleteCrmEntry = (entry) => {
-    return entry.employeeName === currentUser?.username
+    return entry.username === currentUser?.username
   }
 
   const canEditCrmEntry = (entry) => {
-    return entry.employeeName === currentUser?.username
+    return entry.username === currentUser?.username
   }
 
   const handleDeleteClient = () => {
@@ -1265,9 +1265,9 @@ export default function EmployeePanel({ data: initialData, currentUser, username
               <h3 className="client-name">{highlightText(`${person.firstName} ${person.lastName}`, searchTerm)}</h3>
               <span className="client-badge">client</span>
             </div>
-            {person.crm && person.crm.length > 0 ? (
+            {person.crmEntries && person.crmEntries.length > 0 ? (
               <p className="client-preview">
-                Last interaction: {person.crm.length > 0 ? person.crm[person.crm.length - 1].date_of_contact : "No interactions"}
+                Last interaction: {person.crmEntries.length > 0 ? person.crmEntries[person.crmEntries.length - 1].date_of_contact : "No interactions"}
               </p>
             ) : (
               <p className="client-preview no-recent-activities">No recent activities</p>
@@ -1647,21 +1647,21 @@ export default function EmployeePanel({ data: initialData, currentUser, username
               <div className="card-content">
                 <div className="info-item">
                   <div className="info-label">Total CRM Entries</div>
-                  <div className="info-value">{selectedPerson.crm ? selectedPerson.crm.length : 0}</div>
+                  <div className="info-value">{selectedPerson.crmEntries ? selectedPerson.crmEntries.length : 0}</div>
                 </div>
                 <div className="info-item">
                   <div className="info-label">Last Contact Date</div>
                   <div className="info-value">
-                    {selectedPerson.crm && selectedPerson.crm.length > 0
-                      ? selectedPerson.crm[selectedPerson.crm.length - 1].date_of_contact
+                    {selectedPerson.crmEntries && selectedPerson.crmEntries.length > 0
+                      ? selectedPerson.crmEntries[selectedPerson.crmEntries.length - 1].date_of_contact
                       : "No contact recorded"}
                   </div>
                 </div>
                 <div className="info-item">
                   <div className="info-label">Last Contact Type</div>
                   <div className="info-value">
-                    {selectedPerson.crm && selectedPerson.crm.length > 0
-                      ? selectedPerson.crm[selectedPerson.crm.length - 1].contact_type
+                    {selectedPerson.crmEntries && selectedPerson.crmEntries.length > 0
+                      ? selectedPerson.crmEntries[selectedPerson.crmEntries.length - 1].contact_type
                       : "N/A"}
                   </div>
                 </div>
@@ -1712,8 +1712,8 @@ export default function EmployeePanel({ data: initialData, currentUser, username
           </button>
         </div>
         <div className="crm-entries">
-          {selectedPerson.crm && selectedPerson.crm.length > 0 ? (
-            selectedPerson.crm.map((entry, i) => ( // Changed from selectedPerson.crmEntries to selectedPerson.crm
+          {selectedPerson.crmEntries && selectedPerson.crmEntries.length > 0 ? (
+            selectedPerson.crmEntries.map((entry, i) => (
               <div key={entry.id || `crm-${i}`} className="crm-entry" style={{ animationDelay: `${i * 0.1}s` }}>
                 <div className="crm-entry-header">
                   <div className="crm-entry-title" onClick={() => toggleCrmExpansion(entry.id || `crm-${i}`)}>


### PR DESCRIPTION
## Summary
- simplify CRM open/close animation
- show username when employee name missing on CRM history
- make employee panel use `crmEntries` array
- allow deleting/editting CRM entries by username

## Testing
- `npm run lint` *(fails: no-unused-vars and other errors)*

------
https://chatgpt.com/codex/tasks/task_e_68497ce6e5c0832baee776ccb1b9870d