### PR TITLE
Display employee CRM history

### DIFF
--- a/src/components/adminPanel/adminPanel.jsx
+++ b/src/components/adminPanel/adminPanel.jsx
@@ -1076,7 +1076,7 @@ export default function AdminPanel({ data: initialData }) {
       )
     }
 
-    if (selectedPerson.type === "employee") {
+    if (selectedPerson.marketingConsent === undefined) {
       return (
         <div className="crm-container">
           <div className="crm-header">


### PR DESCRIPTION
## Summary
- show CRM records created by an employee in admin panel
- collect CRM entries from all clients and render them for the selected employee

## Testing
- `npm run lint`

------
https://chatgpt.com/codex/tasks/task_e_684bfc2b5824832b9d8ade4f99c42e19